### PR TITLE
fix(announcements): prevent duplicate reaction in local state

### DIFF
--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -109,7 +109,7 @@ function applyLocally(reaction: string, delta: number) {
 	}
 
 	const nextMyReactions = delta > 0
-		? [...myReactions.value, reaction]
+		? (myReactions.value.includes(reaction) ? myReactions.value : [...myReactions.value, reaction])
 		: myReactions.value.filter(r => r !== reaction);
 
 	reactions.value = nextReactions;


### PR DESCRIPTION
## 問題

同じリアクションをピッカーで2回以上選ぶと、UI上ではカウントが増えたように見える（リロードすると正常に戻る）。

## 原因

`applyLocally` 内で `delta > 0` の時、`myReactions` 配列に重複チェックなしに追加していた。

- APIは「既にリアクション済み」として正しく弾く
- しかし楽観的更新が重複適用されるため、UI上では追加されたように見える
- サーバーの状態は正しいのでリロードで戻る

```ts
// 修正前
const nextMyReactions = delta > 0
    ? [...myReactions.value, reaction]  // 重複チェックなし

// 修正後
const nextMyReactions = delta > 0
    ? (myReactions.value.includes(reaction) ? myReactions.value : [...myReactions.value, reaction])
```

## 確認方法

1. お知らせにリアクションを1つ付ける
2. 同じリアクションをピッカーから再度選ぶ
3. カウントが増えず、ボタンの見た目も変わらないことを確認

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment