### PR TITLE
fix: prevent duplicate announcement reactions on rapid clicks

### DIFF
--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -70,6 +70,7 @@ const canToggle = computed(() => $i != null);
 
 const reactions = ref<Record<string, number>>({ ...props.reactions });
 const myReactions = ref<string[]>([...props.myReactions]);
+const toggling = ref(false);
 
 watch(() => props.reactions, (newReactions) => {
 	reactions.value = { ...newReactions };
@@ -118,12 +119,13 @@ function applyLocally(reaction: string, delta: number) {
 }
 
 async function toggle(reaction: string) {
-	if (!canToggle.value) return;
+	if (!canToggle.value || toggling.value) return;
 
 	const previousReactions = { ...reactions.value };
 	const previousMyReactions = [...myReactions.value];
 	const isReacted = previousMyReactions.includes(reaction);
 
+	toggling.value = true;
 	applyLocally(reaction, isReacted ? -1 : 1);
 
 	try {
@@ -147,6 +149,8 @@ async function toggle(reaction: string) {
 			type: 'error',
 			text: i18n.ts.somethingHappened,
 		});
+	} finally {
+		toggling.value = false;
 	}
 }
 


### PR DESCRIPTION
連打による重複リアクションを防ぐため、toggle実行中のフラグを追加。

## 変更内容
- toggling フラグを追加し、API実行中は追加のクリックを無視
- finally でフラグをクリアし、成功/失敗どちらでも次の操作を可能に

## 問題
楽観的更新により myReactions.value は即座に更新されるが、連打時に複数の toggle() が並行実行され、それぞれが古い previousMyReactions を参照してしまう。

## テスト
- ローカルで連打テスト済み
- 型チェック通過
