### PR TITLE
fix: お知らせリアクションのピッカー出力を正規化

### DIFF
--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -70,6 +70,7 @@ const canToggle = computed(() => $i != null);
 
 const reactions = ref<Record<string, number>>({ ...props.reactions });
 const myReactions = ref<string[]>([...props.myReactions]);
+const toggling = ref(false);
 
 watch(() => props.reactions, (newReactions) => {
 	reactions.value = { ...newReactions };
@@ -118,12 +119,13 @@ function applyLocally(reaction: string, delta: number) {
 }
 
 async function toggle(reaction: string) {
-	if (!canToggle.value) return;
+	if (!canToggle.value || toggling.value) return;
 
 	const previousReactions = { ...reactions.value };
 	const previousMyReactions = [...myReactions.value];
 	const isReacted = previousMyReactions.includes(reaction);
 
+	toggling.value = true;
 	applyLocally(reaction, isReacted ? -1 : 1);
 
 	try {
@@ -147,6 +149,8 @@ async function toggle(reaction: string) {
 			type: 'error',
 			text: i18n.ts.somethingHappened,
 		});
+	} finally {
+		toggling.value = false;
 	}
 }
 

--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -154,13 +154,25 @@ async function toggle(reaction: string) {
 	}
 }
 
+/**
+ * ピッカーが返す生の絵文字文字列をバックエンドの normalizeReaction と同じルールで正規化する。
+ * - カスタム絵文字: :name@.: → :name:（お知らせはローカル専用のため @. を除去）
+ * - Unicode絵文字: 異体字セレクタ(U+FE0F)除去（ZWJ 合字はそのまま）
+ */
+function normalizePickedReaction(reaction: string): string {
+	const localCustom = reaction.replace(/^:([\w+-]+)@\.:$/, ':$1:');
+	if (localCustom !== reaction) return localCustom;
+	return reaction.match('\u200d') ? reaction : reaction.replace(/\ufe0f/g, '');
+}
+
 function pick() {
 	if (!canToggle.value) return;
 
 	reactionPicker.show(pickerButtonEl.value ?? null, null, (reaction) => {
+		const normalized = normalizePickedReaction(reaction);
 		// すでに付けているリアクションを選んだ場合は何もしない
-		if (myReactions.value.includes(reaction)) return;
-		toggle(reaction);
+		if (myReactions.value.includes(normalized)) return;
+		toggle(normalized);
 	});
 }
 </script>


### PR DESCRIPTION
## 修正内容

ピッカーから返されるUnicode絵文字に異体字セレクタ (U+FE0F) が含まれる場合があるが、バックエンドは正規化した形式で保存する。この不一致により `myReactions.includes()` が失敗し、重複リアクションが可能になっていた。

バックエンドの `normalizeReaction()` と同じルールをフロントエンドで適用：
- Unicode絵文字から異体字セレクタを除去（ZWJ合字は除く）
- ローカルカスタム絵文字の `@.` 接尾辞を除去

## 検証

- [x] frontend typecheck
- [x] frontend build
- [x] dev環境で動作確認（コミット d53343ee26）

## 関連

- 前回修正 #71 では UI上の重複チェックを追加したが、正規化の不一致により不完全だった