### PR TITLE
fix(frontend): お知らせリアクションのカスタム絵文字形式を統一

### DIFF
--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -70,6 +70,7 @@ const canToggle = computed(() => $i != null);
 
 const reactions = ref<Record<string, number>>({ ...props.reactions });
 const myReactions = ref<string[]>([...props.myReactions]);
+const toggling = ref(false);
 
 watch(() => props.reactions, (newReactions) => {
 	reactions.value = { ...newReactions };
@@ -118,12 +119,13 @@ function applyLocally(reaction: string, delta: number) {
 }
 
 async function toggle(reaction: string) {
-	if (!canToggle.value) return;
+	if (!canToggle.value || toggling.value) return;
 
 	const previousReactions = { ...reactions.value };
 	const previousMyReactions = [...myReactions.value];
 	const isReacted = previousMyReactions.includes(reaction);
 
+	toggling.value = true;
 	applyLocally(reaction, isReacted ? -1 : 1);
 
 	try {
@@ -147,6 +149,8 @@ async function toggle(reaction: string) {
 			type: 'error',
 			text: i18n.ts.somethingHappened,
 		});
+	} finally {
+		toggling.value = false;
 	}
 }
 

--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -154,13 +154,25 @@ async function toggle(reaction: string) {
 	}
 }
 
+/**
+ * ピッカーが返す生の絵文字文字列をバックエンドの normalizeReaction と同じルールで正規化する。
+ * - カスタム絵文字: :name@.: → :name:（お知らせはローカル専用のため @. を除去）
+ * - Unicode絵文字: 異体字セレクタ(U+FE0F)除去（ZWJ 合字はそのまま）
+ */
+function normalizePickedReaction(reaction: string): string {
+	const localCustom = reaction.replace(/^:([\w+-]+)@\.:$/, ':$1:');
+	if (localCustom !== reaction) return localCustom;
+	return reaction.match('\u200d') ? reaction : reaction.replace(/\ufe0f/g, '');
+}
+
 function pick() {
 	if (!canToggle.value) return;
 
 	reactionPicker.show(pickerButtonEl.value ?? null, null, (reaction) => {
+		const normalized = normalizePickedReaction(reaction);
 		// すでに付けているリアクションを選んだ場合は何もしない
-		if (myReactions.value.includes(reaction)) return;
-		toggle(reaction);
+		if (myReactions.value.includes(normalized)) return;
+		toggle(normalized);
 	});
 }
 </script>

--- a/packages/frontend/src/components/MkAnnouncementReactions.vue
+++ b/packages/frontend/src/components/MkAnnouncementReactions.vue
@@ -155,13 +155,15 @@ async function toggle(reaction: string) {
 }
 
 /**
- * ピッカーが返す生の絵文字文字列をバックエンドの normalizeReaction と同じルールで正規化する。
- * - カスタム絵文字: :name@.: → :name:（お知らせはローカル専用のため @. を除去）
- * - Unicode絵文字: 異体字セレクタ(U+FE0F)除去（ZWJ 合字はそのまま）
+ * ピッカーが返す生の絵文字文字列をバックエンドの decodeReaction と同じルールで変換する。
+ * - カスタム絵文字: :name: → :name@.: (APIレスポンスがこの形式で返ってくる)
+ * - Unicode絵文字: 異体字セレクタ(U+FE0F)除去(ZWJ 合字はそのまま)
  */
 function normalizePickedReaction(reaction: string): string {
-	const localCustom = reaction.replace(/^:([\w+-]+)@\.:$/, ':$1:');
-	if (localCustom !== reaction) return localCustom;
+	// カスタム絵文字を :name@.: 形式に変換
+	const customMatch = reaction.match(/^:([\w+-]+):$/);
+	if (customMatch) return `:${customMatch[1]}@.:`;
+	// Unicode絵文字の異体字セレクタを除去
 	return reaction.match('\u200d') ? reaction : reaction.replace(/\ufe0f/g, '');
 }
 


### PR DESCRIPTION
## 概要
お知らせリアクションで既に付けたカスタム絵文字を再選択すると重複してしまうバグを修正。

## 原因
- バックエンドの `AnnouncementReactionService` は `decodeReaction()` を通して `:name:` を `:name@.:` 形式で返す
- フロントエンドのピッカーは `:name:` 形式のまま返す
- `myReactions.includes(reaction)` の比較が失敗していた

## 修正内容
`normalizePickedReaction()` を修正して、ピッカーが返す `:name:` を `:name@.:` に変換するように変更。

## テスト
- [x] 既にリアクション済みのカスタム絵文字を「最近使用」から選択
- [x] 重複せず何も起こらないことを確認
- [x] Unicode絵文字は従来通り動作

Co-Authored-By: Zel9278 <zel9278@gmail.com>